### PR TITLE
Recalculate stats button

### DIFF
--- a/GamingGaiden.ps1
+++ b/GamingGaiden.ps1
@@ -221,6 +221,7 @@ try {
     $menuItemSeparator5 = New-Object Windows.Forms.ToolStripSeparator
     $menuItemSeparator6 = New-Object Windows.Forms.ToolStripSeparator
     $menuItemSeparator7 = New-Object Windows.Forms.ToolStripSeparator
+    $menuItemSeparator8 = New-Object Windows.Forms.ToolStripSeparator
 
     $IconRunning = [System.Drawing.Icon]::new(".\icons\running.ico")
     $IconTracking = [System.Drawing.Icon]::new(".\icons\tracking.ico")
@@ -248,6 +249,7 @@ try {
     $editPlatformMenuItem = CreateMenuItem "Edit Emulator"
     $gamingPCMenuItem = CreateMenuItem "Gaming PCs"
     $nameProfilesMenuItem = CreateMenuItem "Name Profiles"
+    $recalculateStatsMenuItem = CreateMenuItem "Recalculate All Statistics"
     $openInstallDirectoryMenuItem = CreateMenuItem "Open Install Directory"
     $null = $settingsSubMenuItem.DropDownItems.Add($addGameMenuItem)
     $null = $settingsSubMenuItem.DropDownItems.Add($editGameMenuItem)
@@ -257,6 +259,8 @@ try {
     $null = $settingsSubMenuItem.DropDownItems.Add($menuItemSeparator7)
     $null = $settingsSubMenuItem.DropDownItems.Add($gamingPCMenuItem)
     $null = $settingsSubMenuItem.DropDownItems.Add($nameProfilesMenuItem)
+    $null = $settingsSubMenuItem.DropDownItems.Add($menuItemSeparator8)
+    $null = $settingsSubMenuItem.DropDownItems.Add($recalculateStatsMenuItem)
     $null = $settingsSubMenuItem.DropDownItems.Add($openInstallDirectoryMenuItem)
 
     $statsSubMenuItem = CreateMenuItem "Statistics"
@@ -446,6 +450,19 @@ try {
     $nameProfilesMenuItem.Add_Click({
         Log "Starting profile naming"
         ExecuteSettingsFunction -SettingsFunctionToCall $function:RenderProfileSettingsForm
+    })
+
+    $recalculateStatsMenuItem.Add_Click({
+        Log "Starting manual recalculation of all statistics."
+        try {
+            [System.Threading.Monitor]::Enter($dbLock)
+            Update-AllStats
+            UpdateAllStatsInBackground
+        }
+        finally {
+            [System.Threading.Monitor]::Exit($dbLock)
+        }
+        $AppNotifyIcon.ShowBalloonTip(3000, "Recalculation Complete", "All game statistics have been successfully recalculated.", [System.Windows.Forms.ToolTipIcon]::Info)
     })
 
     $openInstallDirectoryMenuItem.Add_Click({

--- a/modules/StorageFunctions.psm1
+++ b/modules/StorageFunctions.psm1
@@ -331,9 +331,8 @@ function Switch-SessionProfile($SessionId, $NewProfileId) {
     }
 
     $gameName = $session.game_name
-    $duration = $session.session_duration_minutes
     $oldProfileId = $session.profile_id
-    $sessionDate = ([datetime]'1970-01-01 00:00:00Z').AddSeconds($session.session_start_time).ToString("yyyy-MM-dd")
+    $sessionDate = ([datetime]'1970-01-01 00:00:00Z').AddSeconds($session.session_start_time).ToLocalTime().ToString("yyyy-MM-dd")
 
     if ($oldProfileId -eq $NewProfileId) {
         Log "Session is already on this profile."
@@ -343,50 +342,79 @@ function Switch-SessionProfile($SessionId, $NewProfileId) {
     # Get game ID
     $gameId = (RunDBQuery "SELECT id FROM games WHERE name LIKE '$gameName'").id
 
-    # Update game_stats for old profile
-    $oldGameStats = RunDBQuery "SELECT * FROM game_stats WHERE game_id = $gameId AND profile_id = $oldProfileId"
-    if ($null -ne $oldGameStats) {
-        $newPlayTime = $oldGameStats.play_time - $duration
-        $newSessionCount = $oldGameStats.session_count - 1
-        RunDBQuery "UPDATE game_stats SET play_time = $newPlayTime, session_count = $newSessionCount WHERE id = $($oldGameStats.id)"
-    }
-
-    # Update game_stats for new profile
-    $newGameStats = RunDBQuery "SELECT * FROM game_stats WHERE game_id = $gameId AND profile_id = $NewProfileId"
-    if ($null -ne $newGameStats) {
-        $newPlayTime = $newGameStats.play_time + $duration
-        $newSessionCount = $newGameStats.session_count + 1
-        RunDBQuery "UPDATE game_stats SET play_time = $newPlayTime, session_count = $newSessionCount WHERE id = $($newGameStats.id)"
-    }
-    else {
-        # If the game doesn't have stats for the new profile, create them
-        RunDBQuery "INSERT INTO game_stats (game_id, profile_id, play_time, last_play_date, completed, status, session_count, idle_time) VALUES ($gameId, $NewProfileId, $duration, $($session.session_start_time), 'FALSE', 'Playing', 1, 0)"
-    }
-
-    # Update daily_playtime for old profile
-    $oldDailyPlaytime = RunDBQuery "SELECT * FROM daily_playtime WHERE play_date = '$sessionDate' AND profile_id = $oldProfileId"
-    if ($null -ne $oldDailyPlaytime) {
-        $newDailyPlayTime = $oldDailyPlaytime.play_time - $duration
-        if ($newDailyPlayTime -le 0) {
-            RunDBQuery "DELETE FROM daily_playtime WHERE play_date = '$sessionDate' AND profile_id = $oldProfileId"
-        }
-        else {
-            RunDBQuery "UPDATE daily_playtime SET play_time = $newDailyPlayTime WHERE play_date = '$sessionDate' AND profile_id = $oldProfileId"
-        }
-    }
-
-    # Update daily_playtime for new profile
-    $newDailyPlaytime = RunDBQuery "SELECT * FROM daily_playtime WHERE play_date = '$sessionDate' AND profile_id = $NewProfileId"
-    if ($null -ne $newDailyPlaytime) {
-        $newDailyPlayTime = $newDailyPlaytime.play_time + $duration
-        RunDBQuery "UPDATE daily_playtime SET play_time = $newDailyPlayTime WHERE play_date = '$sessionDate' AND profile_id = $NewProfileId"
-    }
-    else {
-        RunDBQuery "INSERT INTO daily_playtime (play_date, play_time, profile_id) VALUES ('$sessionDate', $duration, $NewProfileId)"
-    }
-
-    # Update session
+    # 1. Update session_history
     RunDBQuery "UPDATE session_history SET profile_id = $NewProfileId WHERE id = $SessionId"
+    Log "Updated session history for session $SessionId to profile $NewProfileId"
+
+    # 2. Recalculate stats for both profiles
+    foreach ($profileId in @($oldProfileId, $NewProfileId)) {
+        Log "Recalculating stats for game '$gameName' on profile $profileId"
+
+        # Recalculate play_time and session_count from session_history
+        $recalcQuery = "SELECT COALESCE(SUM(session_duration_minutes), 0) AS total_play_time, COUNT(*) AS total_sessions FROM session_history WHERE game_name LIKE @gameName AND profile_id = @profileId"
+        $recalcStats = RunDBQuery $recalcQuery @{ gameName = $gameName; profileId = $profileId }
+        
+        $totalPlayTime = $recalcStats.total_play_time
+        $totalSessions = $recalcStats.total_sessions
+
+        # Get the last play date
+        $lastPlayDateQuery = "SELECT MAX(session_start_time) as last_play_date FROM session_history WHERE game_name LIKE @gameName AND profile_id = @profileId"
+        $lastPlayDate = (RunDBQuery $lastPlayDateQuery @{ gameName = $gameName; profileId = $profileId }).last_play_date
+        if ($null -eq $lastPlayDate) {
+            $lastPlayDate = 0
+        }
+
+        # Update game_stats
+        $gameStatsExist = RunDBQuery "SELECT id FROM game_stats WHERE game_id = $gameId AND profile_id = $profileId"
+        if ($null -ne $gameStatsExist) {
+            $updateStatsQuery = "UPDATE game_stats SET play_time = @totalPlayTime, session_count = @totalSessions, last_play_date = @lastPlayDate WHERE game_id = @gameId AND profile_id = @profileId"
+            RunDBQuery $updateStatsQuery @{
+                totalPlayTime = $totalPlayTime
+                totalSessions = $totalSessions
+                lastPlayDate  = $lastPlayDate
+                gameId        = $gameId
+                profileId     = $profileId
+            }
+            Log "Updated game_stats for game '$gameName' on profile $profileId. Playtime: $totalPlayTime, Sessions: $totalSessions, Last Played: $lastPlayDate"
+        } else {
+            # If no stats exist for the new profile, create them
+            $insertStatsQuery = "INSERT INTO game_stats (game_id, profile_id, play_time, last_play_date, completed, status, session_count, idle_time) VALUES (@gameId, @profileId, @totalPlayTime, @lastPlayDate, 'FALSE', 'Playing', @totalSessions, 0)"
+            RunDBQuery $insertStatsQuery @{
+                gameId        = $gameId
+                profileId     = $profileId
+                totalPlayTime = $totalPlayTime
+                lastPlayDate  = $lastPlayDate
+                totalSessions = $totalSessions
+            }
+            Log "Inserted game_stats for game '$gameName' on profile $profileId. Playtime: $totalPlayTime, Sessions: $totalSessions, Last Played: $lastPlayDate"
+        }
+
+        # 3. Recalculate daily_playtime for the session date
+        Log "Recalculating daily playtime for date '$sessionDate' on profile $profileId"
+        $dailyPlayTimeQuery = "SELECT COALESCE(SUM(session_duration_minutes), 0) AS daily_total FROM session_history WHERE strftime('%Y-%m-%d', session_start_time, 'unixepoch', 'localtime') = @sessionDate AND profile_id = @profileId"
+        $dailyTotalPlayTime = (RunDBQuery $dailyPlayTimeQuery @{ sessionDate = $sessionDate; profileId = $profileId }).daily_total
+
+        $dailyPlaytimeExists = RunDBQuery "SELECT id FROM daily_playtime WHERE play_date = @sessionDate AND profile_id = @profileId" @{ sessionDate = $sessionDate; profileId = $profileId }
+
+        if ($dailyTotalPlayTime -gt 0) {
+            if ($null -ne $dailyPlaytimeExists) {
+                $updateDailyQuery = "UPDATE daily_playtime SET play_time = @dailyTotalPlayTime WHERE play_date = @sessionDate AND profile_id = @profileId"
+                RunDBQuery $updateDailyQuery @{ dailyTotalPlayTime = $dailyTotalPlayTime; sessionDate = $sessionDate; profileId = $profileId }
+                Log "Updated daily_playtime for '$sessionDate' on profile $profileId to $dailyTotalPlayTime minutes."
+            } else {
+                $insertDailyQuery = "INSERT INTO daily_playtime (play_date, play_time, profile_id) VALUES (@sessionDate, @dailyTotalPlayTime, @profileId)"
+                RunDBQuery $insertDailyQuery @{ sessionDate = $sessionDate; dailyTotalPlayTime = $dailyTotalPlayTime; profileId = $profileId }
+                Log "Inserted daily_playtime for '$sessionDate' on profile $profileId with $dailyTotalPlayTime minutes."
+            }
+        } else {
+            # If there are no more sessions on this date for the profile, remove the daily_playtime entry
+            if ($null -ne $dailyPlaytimeExists) {
+                $deleteDailyQuery = "DELETE FROM daily_playtime WHERE play_date = @sessionDate AND profile_id = @profileId"
+                RunDBQuery $deleteDailyQuery @{ sessionDate = $sessionDate; profileId = $profileId }
+                Log "Deleted daily_playtime for '$sessionDate' on profile $profileId as there are no more sessions."
+            }
+        }
+    }
 }
 
 function RecordPlaytimOnDate($PlayTime) {
@@ -428,4 +456,92 @@ function RecordSessionHistory() {
         SessionDuration  = $SessionDuration
         ProfileId        = $profileId
     }
+}
+
+function Update-AllStats() {
+    Log "Starting full recalculation of all statistics."
+
+    # 1. Recalculate daily_playtime from session_history
+    Log "Calculating daily playtime from session_history."
+    $getDailyPlaytimeQuery = "SELECT strftime('%Y-%m-%d', session_start_time, 'unixepoch', 'localtime') as play_date, SUM(session_duration_minutes) as play_time, profile_id FROM session_history GROUP BY play_date, profile_id"
+    $dailyPlaytimeData = RunDBQuery $getDailyPlaytimeQuery
+    
+    Log "Clearing daily_playtime table."
+    RunDBQuery "DELETE FROM daily_playtime"
+
+    Log "Repopulating daily_playtime with calculated data."
+    if ($null -ne $dailyPlaytimeData) {
+        foreach ($dailyEntry in $dailyPlaytimeData) {
+            $insertQuery = "INSERT OR REPLACE INTO daily_playtime (play_date, play_time, profile_id) VALUES (@playDate, @playTime, @profileId)"
+            RunDBQuery $insertQuery @{
+                playDate  = $dailyEntry.play_date
+                playTime  = $dailyEntry.play_time
+                profileId = $dailyEntry.profile_id
+            }
+        }
+    }
+    Log "Finished repopulating daily_playtime."
+
+    # 2. Recalculate all game_stats
+    Log "Recalculating all game_stats."
+    $games = RunDBQuery "SELECT id, name FROM games"
+    $profiles = Get-Profiles
+
+    foreach ($game in $games) {
+        foreach ($profile in $profiles) {
+            $gameId = $game.id
+            $gameName = $game.name
+            $profileId = $profile.id
+
+            Log "Recalculating stats for game '$gameName' (ID: $gameId) on profile $profileId"
+
+            # Recalculate play_time and session_count from session_history
+            $recalcQuery = "SELECT COALESCE(SUM(session_duration_minutes), 0) AS total_play_time, COUNT(*) AS total_sessions FROM session_history WHERE game_name LIKE @gameName AND profile_id = @profileId"
+            $recalcStats = RunDBQuery $recalcQuery @{ gameName = $gameName; profileId = $profileId }
+
+            $totalPlayTime = $recalcStats.total_play_time
+            $totalSessions = $recalcStats.total_sessions
+
+            # Get the last play date
+            $lastPlayDateQuery = "SELECT MAX(session_start_time) as last_play_date FROM session_history WHERE game_name LIKE @gameName AND profile_id = @profileId"
+            $lastPlayDate = (RunDBQuery $lastPlayDateQuery @{ gameName = $gameName; profileId = $profileId }).last_play_date
+            if ($null -eq $lastPlayDate) {
+                $lastPlayDate = 0
+            }
+
+            # Update or Insert game_stats
+            $gameStatsExist = RunDBQuery "SELECT id FROM game_stats WHERE game_id = $gameId AND profile_id = $profileId"
+            if ($null -ne $gameStatsExist) {
+                if ($totalSessions -gt 0) {
+                    $updateStatsQuery = "UPDATE game_stats SET play_time = @totalPlayTime, session_count = @totalSessions, last_play_date = @lastPlayDate WHERE game_id = @gameId AND profile_id = @profileId"
+                    RunDBQuery $updateStatsQuery @{
+                        totalPlayTime = $totalPlayTime
+                        totalSessions = $totalSessions
+                        lastPlayDate  = $lastPlayDate
+                        gameId        = $gameId
+                        profileId     = $profileId
+                    }
+                    Log "Updated game_stats for game '$gameName' on profile $profileId."
+                } else {
+                    # If no sessions, but stats exist, reset them (except for status/completed flags)
+                    $updateStatsQuery = "UPDATE game_stats SET play_time = 0, session_count = 0, last_play_date = 0 WHERE game_id = @gameId AND profile_id = @profileId"
+                    RunDBQuery $updateStatsQuery @{ gameId = $gameId; profileId = $profileId }
+                    Log "Reset game_stats for game '$gameName' on profile $profileId as no sessions were found."
+                }
+            } elseif ($totalSessions -gt 0) {
+                # If stats don't exist and there are sessions, create a new entry
+                $insertStatsQuery = "INSERT INTO game_stats (game_id, profile_id, play_time, last_play_date, completed, status, session_count, idle_time) VALUES (@gameId, @profileId, @totalPlayTime, @lastPlayDate, 'FALSE', 'Playing', @totalSessions, 0)"
+                RunDBQuery $insertStatsQuery @{
+                    gameId        = $gameId
+                    profileId     = $profileId
+                    totalPlayTime = $totalPlayTime
+                    lastPlayDate  = $lastPlayDate
+                    totalSessions = $totalSessions
+                }
+                Log "Inserted game_stats for game '$gameName' on profile $profileId."
+            }
+        }
+    }
+    Log "Finished recalculating all game_stats."
+    Log "Full statistics recalculation complete."
 }


### PR DESCRIPTION
Added a recalculate stats button that manually recalculates the statistics for the whole app based on the session history page which is useful for mistakes when migrating session data between profiles